### PR TITLE
Create a abstract bootstrapper for the node

### DIFF
--- a/Aggrex.Ecosystem.sln
+++ b/Aggrex.Ecosystem.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26823.1
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{5F9D56CE-CDBF-4471-9359-BC0B0BA5EA13}"
 EndProject
@@ -30,6 +30,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aggrex.Configuration", "src\Aggrex.Configuration\Aggrex.Configuration\Aggrex.Configuration.csproj", "{91A1E4F8-64C8-4437-AE3D-1A30B1D94EBF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aggrex.Neo", "src\Aggrex.Neo\Aggrex.Neo\Aggrex.Neo.csproj", "{D91A3D8C-1306-4D16-96CF-B4C824D87A62}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aggrex.Application", "src\Aggrex.Application\Aggrex.Application.csproj", "{D9DF650B-A621-481F-B417-A89032CC67D3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +83,10 @@ Global
 		{D91A3D8C-1306-4D16-96CF-B4C824D87A62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D91A3D8C-1306-4D16-96CF-B4C824D87A62}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D91A3D8C-1306-4D16-96CF-B4C824D87A62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9DF650B-A621-481F-B417-A89032CC67D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9DF650B-A621-481F-B417-A89032CC67D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9DF650B-A621-481F-B417-A89032CC67D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9DF650B-A621-481F-B417-A89032CC67D3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Aggrex.Application/Aggrex.Application.csproj
+++ b/src/Aggrex.Application/Aggrex.Application.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.6.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aggrex.ConsensusProtocol\Aggrex.ConsensusProtocol\Aggrex.ConsensusProtocol.csproj" />
+    <ProjectReference Include="..\Aggrex.Network\Aggrex.Network.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aggrex.Application/Bootstrapper.cs
+++ b/src/Aggrex.Application/Bootstrapper.cs
@@ -22,9 +22,9 @@ namespace Aggrex.Application
         #region IBootstapper Implementation 
         public void Startup()
         {
-            this.RegisterModules();
+            RegisterModules();
 
-            this.StartLocalNode();
+            StartLocalNode();
         }
 
         public void Shutdown()
@@ -42,12 +42,12 @@ namespace Aggrex.Application
             builder.RegisterModule<ConsensusProtocolModule>();
             builder.RegisterModule<NetworkModule>();
 
-            this._container = builder.Build();
+            _container = builder.Build();
         }
 
         public void StartLocalNode()
         {
-            using (var scope = this._container.BeginLifetimeScope())
+            using (var scope = _container.BeginLifetimeScope())
             {
                 var node = scope.Resolve<ILocalNode>();
                 node.Start();

--- a/src/Aggrex.Application/Bootstrapper.cs
+++ b/src/Aggrex.Application/Bootstrapper.cs
@@ -1,0 +1,58 @@
+﻿using System.Reflection;
+using Aggrex.Configuration.Modules;
+using Aggrex.ConsensusProtocol.Ioc.Modules;
+using Aggrex.Network;
+using Aggrex.Network.Modules;
+using Autofac;
+
+namespace Aggrex.Application
+{
+    public class Bootstrapper : IBootstapper
+    {
+        #region Private Fields 
+        private IContainer _container;
+        #endregion
+
+        #region Constructor
+        public Bootstrapper()
+        {
+        }
+        #endregion
+
+        #region IBootstapper Implementation 
+        public void Startup()
+        {
+            this.RegisterModules();
+
+            this.StartLocalNode();
+        }
+
+        public void Shutdown()
+        {
+        }
+        #endregion
+
+        #region Private Methods 
+        private void RegisterModules()
+        {
+            var executingAssembly = Assembly.GetExecutingAssembly();
+
+            var builder = new ContainerBuilder();
+            builder.RegisterModule<ConfigurationModule>();
+            builder.RegisterModule<ConsensusProtocolModule>();
+            builder.RegisterModule<NetworkModule>();
+
+            this._container = builder.Build();
+        }
+
+        public void StartLocalNode()
+        {
+            using (var scope = this._container.BeginLifetimeScope())
+            {
+                var node = scope.Resolve<ILocalNode>();
+                node.Start();
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Aggrex.Application/IBootstapper.cs
+++ b/src/Aggrex.Application/IBootstapper.cs
@@ -1,0 +1,9 @@
+﻿namespace Aggrex.Application
+{
+    public interface IBootstapper
+    {
+        void Startup();
+
+        void Shutdown();
+    }
+}

--- a/src/Aggrex.Clients/Aggrex.Client.Cli/Aggrex.Client.Cli.csproj
+++ b/src/Aggrex.Clients/Aggrex.Client.Cli/Aggrex.Client.Cli.csproj
@@ -10,10 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Aggrex.Configuration\Aggrex.Configuration\Aggrex.Configuration.csproj" />
-    <ProjectReference Include="..\..\Aggrex.ConsensusProtocol\Aggrex.ConsensusProtocol\Aggrex.ConsensusProtocol.csproj" />
-    <ProjectReference Include="..\..\Aggrex.Network\Aggrex.Network.csproj" />
-    <ProjectReference Include="..\..\Aggrex.VirtualMachine\Aggrex.VirtualMachine\Aggrex.VirtualMachine.csproj" />
+    <ProjectReference Include="..\..\Aggrex.Application\Aggrex.Application.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aggrex.Clients/Aggrex.Client.Cli/Aggrex.Client.Cli.csproj
+++ b/src/Aggrex.Clients/Aggrex.Client.Cli/Aggrex.Client.Cli.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Aggrex.Application\Aggrex.Application.csproj" />
   </ItemGroup>
 

--- a/src/Aggrex.Clients/Aggrex.Client.Cli/Program.cs
+++ b/src/Aggrex.Clients/Aggrex.Client.Cli/Program.cs
@@ -1,12 +1,5 @@
-﻿using Aggrex.Network;
-using System;
-using System.Net;
-using System.Net.Sockets;
-using System.Threading.Tasks;
-using Aggrex.Configuration.Modules;
-using Aggrex.ConsensusProtocol.Ioc.Modules;
-using Aggrex.Network.Modules;
-using Autofac;
+﻿using System;
+using Aggrex.Application;
 
 namespace Aggrex.Client.Cli
 {
@@ -16,21 +9,10 @@ namespace Aggrex.Client.Cli
         {
             Console.Title = "Seed Peer";
 
-            ContainerBuilder builder = new ContainerBuilder();
+            var networkBootstrapper = new Bootstrapper();
+            networkBootstrapper.Startup();
 
-            builder.RegisterModule<ConfigurationModule>();
-            builder.RegisterModule<ConsensusProtocolModule>();
-            builder.RegisterModule<NetworkModule>();
-
-            var container = builder.Build();
-
-            using (var scope = container.BeginLifetimeScope())
-            {
-                ILocalNode node = scope.Resolve<ILocalNode>();
-                node.Start();
-
-                Console.ReadKey();
-            }
+            Console.ReadKey();
         }
     }
 }

--- a/src/Aggrex.Clients/Aggrex.Client.Cli2/Aggrex.Client.Cli2.csproj
+++ b/src/Aggrex.Clients/Aggrex.Client.Cli2/Aggrex.Client.Cli2.csproj
@@ -6,13 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\Aggrex.Configuration\Aggrex.Configuration\Aggrex.Configuration.csproj" />
-    <ProjectReference Include="..\..\Aggrex.ConsensusProtocol\Aggrex.ConsensusProtocol\Aggrex.ConsensusProtocol.csproj" />
-    <ProjectReference Include="..\..\Aggrex.Network\Aggrex.Network.csproj" />
+    <ProjectReference Include="..\..\Aggrex.Application\Aggrex.Application.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aggrex.Clients/Aggrex.Client.Cli2/Program.cs
+++ b/src/Aggrex.Clients/Aggrex.Client.Cli2/Program.cs
@@ -1,17 +1,5 @@
 ﻿using System;
-using System.Globalization;
-using System.IO;
-using System.Net;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
-using Aggrex.Common;
-using Aggrex.Configuration.Modules;
-using Aggrex.ConsensusProtocol.Ioc.Modules;
-using Aggrex.Network;
-using Aggrex.Network.Modules;
-using Aggrex.Network.Requests;
-using Autofac;
+using Aggrex.Application;
 
 namespace Aggrex.Client.Cli2
 {
@@ -21,22 +9,10 @@ namespace Aggrex.Client.Cli2
         {
             Console.Title = "P2";
 
-            ContainerBuilder builder = new ContainerBuilder();
+            var networkBootstrapper = new Bootstrapper();
+            networkBootstrapper.Startup();
 
-            builder.RegisterModule<ConfigurationModule>();
-            builder.RegisterModule<ConsensusProtocolModule>();
-            builder.RegisterModule<NetworkModule>();
-
-            var container = builder.Build();
-
-            using (var scope = container.BeginLifetimeScope())
-            {
-                ILocalNode node = scope.Resolve<ILocalNode>();
-                node.Start();
-
-                Console.ReadKey();
-            }
-
+            Console.ReadKey();
         }
     }
 }

--- a/src/Aggrex.Clients/Aggrex.Client.Cli3/Aggrex.Client.Cli3.csproj
+++ b/src/Aggrex.Clients/Aggrex.Client.Cli3/Aggrex.Client.Cli3.csproj
@@ -6,13 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\Aggrex.Configuration\Aggrex.Configuration\Aggrex.Configuration.csproj" />
-    <ProjectReference Include="..\..\Aggrex.ConsensusProtocol\Aggrex.ConsensusProtocol\Aggrex.ConsensusProtocol.csproj" />
-    <ProjectReference Include="..\..\Aggrex.Network\Aggrex.Network.csproj" />
+    <ProjectReference Include="..\..\Aggrex.Application\Aggrex.Application.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aggrex.Clients/Aggrex.Client.Cli3/Program.cs
+++ b/src/Aggrex.Clients/Aggrex.Client.Cli3/Program.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Net;
-using Aggrex.Configuration.Modules;
-using Aggrex.ConsensusProtocol.Ioc.Modules;
-using Aggrex.Network;
-using Aggrex.Network.Modules;
-using Autofac;
+using Aggrex.Application;
 
 namespace Aggrex.Client.Cli3
 {
@@ -14,21 +9,10 @@ namespace Aggrex.Client.Cli3
         {
             Console.Title = "P3";
 
-            ContainerBuilder builder = new ContainerBuilder();
+            var networkBootstrapper = new Bootstrapper();
+            networkBootstrapper.Startup();
 
-            builder.RegisterModule<ConfigurationModule>();
-            builder.RegisterModule<ConsensusProtocolModule>();
-            builder.RegisterModule<NetworkModule>();
-
-            var container = builder.Build();
-
-            using (var scope = container.BeginLifetimeScope())
-            {
-                ILocalNode node = scope.Resolve<ILocalNode>();
-                node.Start();
-
-                Console.ReadKey();
-            }
+            Console.ReadKey();
         }
     }
 }

--- a/src/Aggrex.Clients/Aggrex.Client.Cli4/Aggrex.Client.Cli4.csproj
+++ b/src/Aggrex.Clients/Aggrex.Client.Cli4/Aggrex.Client.Cli4.csproj
@@ -6,13 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\Aggrex.Configuration\Aggrex.Configuration\Aggrex.Configuration.csproj" />
-    <ProjectReference Include="..\..\Aggrex.ConsensusProtocol\Aggrex.ConsensusProtocol\Aggrex.ConsensusProtocol.csproj" />
-    <ProjectReference Include="..\..\Aggrex.Network\Aggrex.Network.csproj" />
+    <ProjectReference Include="..\..\Aggrex.Application\Aggrex.Application.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aggrex.Clients/Aggrex.Client.Cli4/Program.cs
+++ b/src/Aggrex.Clients/Aggrex.Client.Cli4/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using Aggrex.Application;
 using Aggrex.Configuration.Modules;
 using Aggrex.ConsensusProtocol.Ioc.Modules;
 using Aggrex.Network;
@@ -14,21 +15,10 @@ namespace Aggrex.Client.Cli4
         {
             Console.Title = "P4";
 
-            ContainerBuilder builder = new ContainerBuilder();
+            var networkBootstrapper = new Bootstrapper();
+            networkBootstrapper.Startup();
 
-            builder.RegisterModule<ConfigurationModule>();
-            builder.RegisterModule<ConsensusProtocolModule>();
-            builder.RegisterModule<NetworkModule>();
-
-            var container = builder.Build();
-
-            using (var scope = container.BeginLifetimeScope())
-            {
-                ILocalNode node = scope.Resolve<ILocalNode>();
-                node.Start();
-
-                Console.ReadKey();
-            }
+            Console.ReadKey();
         }
     }
 }


### PR DESCRIPTION
The clients should not be able to know how the NEO node structure and should call the bootstrapper that setup everything that is need to start the node.